### PR TITLE
Artifact.download_as_url controls the way to download artifacts

### DIFF
--- a/src/polyswarmdconfig/artifact.py
+++ b/src/polyswarmdconfig/artifact.py
@@ -39,6 +39,7 @@ class Artifact(Config):
     limit: int = 256
     fallback_max_size: int = DEFAULT_FALLBACK_SIZE
     max_size: int = DEFAULT_FALLBACK_SIZE
+    download_as_url: bool = True
 
     def __post_init__(self):
         if self.limit < 1 or self.limit > 256:


### PR DESCRIPTION
See: https://github.com/polyswarm/polyswarmd-fast-artifacts/pull/8/commits/0d15caa